### PR TITLE
Fix issue 1 by handling more filename cases in the ExtensionValidator

### DIFF
--- a/src/main/java/io/github/sashirestela/slimvalidator/validators/ExtensionValidator.java
+++ b/src/main/java/io/github/sashirestela/slimvalidator/validators/ExtensionValidator.java
@@ -36,6 +36,8 @@ public class ExtensionValidator implements ConstraintValidator<Extension, Object
             fileName = ((File) value).getName();
         } else if (value instanceof Path) {
             fileName = ((Path) value).getFileName().toString();
+        } else if (value instanceof String) {
+            throw new ValidationException("Cannot get a extension from java.lang.String.");
         } else {
             throw new ValidationException("Input must be a File or Path.");
         }

--- a/src/main/java/io/github/sashirestela/slimvalidator/validators/ExtensionValidator.java
+++ b/src/main/java/io/github/sashirestela/slimvalidator/validators/ExtensionValidator.java
@@ -29,14 +29,27 @@ public class ExtensionValidator implements ConstraintValidator<Extension, Object
         return Arrays.stream(extensions).anyMatch(ext -> ext.equals(getExtension(value)));
     }
 
-    private String getExtension(Object value) {
-        if (value instanceof Path) {
-            return ((Path) value).toString().split("\\.")[1];
-        } else if (value instanceof File) {
-            return ((File) value).getName().split("\\.")[1];
-        } else {
-            throw new ValidationException("Cannot get a extension from {0}.", value.getClass().getName(), null);
-        }
-    }
+    private String getExtension(Object value) throws IllegalArgumentException {
+        String fileName;
 
+        if (value instanceof File) {
+            fileName = ((File) value).getName();
+        } else if (value instanceof Path) {
+            fileName = ((Path) value).getFileName().toString();
+        } else {
+            throw new ValidationException("Input must be a File or Path.");
+        }
+
+        if (fileName == null || fileName.isEmpty()) {
+            throw new ValidationException("File name is null or empty.");
+        }
+
+        int lastDotIndex = fileName.lastIndexOf(".");
+
+        if (lastDotIndex == -1 || lastDotIndex == 0 || lastDotIndex == fileName.length() - 1) {
+            throw new ValidationException("No valid file extension found.");
+        }
+
+        return fileName.substring(lastDotIndex + 1);
+    }
 }

--- a/src/test/java/io/github/sashirestela/slimvalidator/validators/ExtensionValidatorTest.java
+++ b/src/test/java/io/github/sashirestela/slimvalidator/validators/ExtensionValidatorTest.java
@@ -59,6 +59,90 @@ class ExtensionValidatorTest {
         assertEquals(expectedMessage, actualMessage);
     }
 
+    @Test
+    void shouldThrownExceptionForHiddenFilesInFile() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File(".hiddenfile");
+        var exception = assertThrows(ValidationException.class, () -> validator.isValid(file));
+        var actualMessage = exception.getMessage();
+        var expectedMessage = "No valid file extension found.";
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void shouldThrownExceptionForHiddenFilesInPath() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File(".hiddenfile");
+        var exception = assertThrows(ValidationException.class, () -> validator.isValid(file.toPath()));
+        var actualMessage = exception.getMessage();
+        var expectedMessage = "No valid file extension found.";
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void shouldThrownExceptionForEmptyFilenameInFile() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File("");
+        var exception = assertThrows(ValidationException.class, () -> validator.isValid(file));
+        var actualMessage = exception.getMessage();
+        var expectedMessage = "File name is null or empty.";
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void shouldThrownExceptionForEmptyFilenameInPath() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File("");
+        var exception = assertThrows(ValidationException.class, () -> validator.isValid(file.toPath()));
+        var actualMessage = exception.getMessage();
+        var expectedMessage = "File name is null or empty.";
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void shouldSucceedWithExtraPeriodsInFilename() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File("/a/b/c/foo.bar.baz.mp3");
+        assertEquals(Boolean.TRUE, validator.isValid(file));
+    }
+
+    @Test
+    void shouldSucceedWithExtraPeriodsInPath() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File("a/b/c/foo.bar.baz.mp3");
+        assertEquals(Boolean.TRUE, validator.isValid(file.toPath()));
+    }
+
+    @Test
+    void shouldReturnFalseWithExtraPeriodsInFile() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File("a/b/c/foo.mp3.wav.txt");
+        assertEquals(Boolean.FALSE, validator.isValid(file));
+    }
+
+    @Test
+    void shouldReturnFalseWithExtraPeriodsInPath() {
+        var validator = new ExtensionValidator();
+        var annotation = Sample.extension(new String[] { "mp3", "wav" });
+        validator.initialize(annotation);
+        File file = new File("a/b/c/foo.mp3.wav.txt");
+        assertEquals(Boolean.FALSE, validator.isValid(file.toPath()));
+    }
+
     static class Sample {
 
         static Extension extension(String[] value) {


### PR DESCRIPTION
Now the validator handles filenames that have additional . characters and it handles 'hidden' files.
